### PR TITLE
Wait for spider before shutdown the driver

### DIFF
--- a/scrapy_headless/middlewares.py
+++ b/scrapy_headless/middlewares.py
@@ -98,6 +98,8 @@ class SeleniumMiddleware:
         return SeleniumResponse(driver.current_url, body=body, encoding='utf-8', request=request)
 
     def process_spider_output(self, response, result, spider):
+        for i in result:
+            yield i
         """Shutdown the driver when spider is finished processing the response"""
         response.interact.quit()
         return result


### PR DESCRIPTION
Workaround for this https://github.com/scrapy/scrapy/issues/5548

Because Scrapy by default does not wait for spider `parse` if it is a generator function before calling the `process_spider_output` from the middleware.